### PR TITLE
Refreshable ensure initialized

### DIFF
--- a/src/Mvvm.Controls/Mvvm.Controls.csproj
+++ b/src/Mvvm.Controls/Mvvm.Controls.csproj
@@ -93,6 +93,7 @@
             <PackagePath></PackagePath>
             <Pack>True</Pack>
         </None>
+		<None Remove="obj\**" />
     </ItemGroup>
 
 

--- a/src/Mvvm.Controls/Mvvm/RefreshFailedException.cs
+++ b/src/Mvvm.Controls/Mvvm/RefreshFailedException.cs
@@ -1,0 +1,21 @@
+using System;
+
+#nullable enable
+
+namespace RFBCodeWorks.Mvvm
+{
+    /// <summary>
+    /// An exception that occurs when the refresh of a <see cref="RefreshableSelector{T, TList, TSelectedValue}"/> failes to refresh
+    /// </summary>
+    public class RefreshFailedException : Exception
+    {
+        /// <inheritdoc cref="Exception.Exception()"/>
+        public RefreshFailedException() { }
+        
+        /// <inheritdoc cref="Exception.Exception(string)"/>
+        public RefreshFailedException(string message) : base(message) { }
+
+        /// <inheritdoc cref="Exception.Exception(string, Exception)"/>
+        public RefreshFailedException(string message, Exception? innerException) : base(message, innerException) { }
+    }
+}

--- a/src/Mvvm.Controls/Mvvm/RefreshFailedException.cs
+++ b/src/Mvvm.Controls/Mvvm/RefreshFailedException.cs
@@ -5,7 +5,7 @@ using System;
 namespace RFBCodeWorks.Mvvm
 {
     /// <summary>
-    /// An exception that occurs when the refresh of a <see cref="RefreshableSelector{T, TList, TSelectedValue}"/> failes to refresh
+    /// An exception that occurs when the refresh of a <see cref="RefreshableSelector{T, TList, TSelectedValue}"/> fails to refresh
     /// </summary>
     public class RefreshFailedException : Exception
     {

--- a/src/Mvvm.Controls/Mvvm/RefreshableSelector.cs
+++ b/src/Mvvm.Controls/Mvvm/RefreshableSelector.cs
@@ -204,8 +204,9 @@ namespace RFBCodeWorks.Mvvm
             }
             finally
             {
+                OnPropertyChanging(EventArgSingletons.IsRefreshing);
                 Interlocked.Exchange(ref _isRefreshing, 0);
-                OnPropertyChanged(nameof(IsRefreshing));
+                OnPropertyChanged(EventArgSingletons.IsRefreshing);
             }
         }
 

--- a/src/Mvvm.Controls/Mvvm/RefreshableSelector.cs
+++ b/src/Mvvm.Controls/Mvvm/RefreshableSelector.cs
@@ -165,10 +165,18 @@ namespace RFBCodeWorks.Mvvm
         private void RefreshAction()
         {
             if (_refresh is null) return;
+            var tcs = new TaskCompletionSource<bool>();
+            _isRefreshingTcs = tcs.Task;
             try
             {
                 IsRefreshing = true;
-                Items = _refresh();
+                var result = _refresh();
+                tcs.SetResult(true);
+                Items = result;
+            }
+            catch(Exception e)
+            {
+                tcs.SetException(e);
             }
             finally
             {
@@ -235,6 +243,22 @@ namespace RFBCodeWorks.Mvvm
         /// <exception cref="OperationCanceledException" />
         public void EnsureInitialized(TimeSpan? maxWaitTime = null)
         {
+            // Call the specialized method for asynchronous waiting
+            if (RefreshCommand is IAsyncRelayCommand)
+            {
+                using CancellationTokenSource waitTime = new(maxWaitTime ?? TimeSpan.FromMilliseconds(3000));
+                try
+                {
+                    EnsureInitializedAsync(waitTime.Token).Wait(waitTime.Token);
+                    return;
+                }
+                catch (OperationCanceledException e) when (waitTime.IsCancellationRequested)
+                {
+                    ThrowRefreshFailedException("Exceeded maximum wait time for asynchronous collection initialization.", e);
+                }
+            }
+
+            // synchronous command logic
             bool usingToken = false;
             try
             {
@@ -244,25 +268,16 @@ namespace RFBCodeWorks.Mvvm
                     {
                         ThrowRefreshFailedException("Unable to initialize collection: RefreshCommand.CanExecute() returned false");
                     }
-                    if (RefreshCommand is IAsyncRelayCommand)
-                    {
-                        usingToken = true;
-                        using CancellationTokenSource waitTime = new(maxWaitTime ?? TimeSpan.FromMilliseconds(3000));
-                        RefreshAsync(waitTime.Token).Wait(waitTime.Token);
-                    }
                     else
                     {
                         RefreshCommand.Execute(null);
                     }
                 }
-                else if (IsRefreshing)
+                else if (IsRefreshing && _isRefreshingTcs is not null)
                 {
                     usingToken = true;
                     using CancellationTokenSource waitTime = new(maxWaitTime ?? TimeSpan.FromMilliseconds(3000));
-                    SpinWait.SpinUntil(() => waitTime.IsCancellationRequested || IsRefreshing == false);
-                    
-                    if (IsRefreshing) 
-                        waitTime.Token.ThrowIfCancellationRequested();
+                    _isRefreshingTcs.Wait(waitTime.Token);
                 }
             }
             catch (RefreshFailedException) { ResetInitializedState(); throw; }
@@ -301,7 +316,6 @@ namespace RFBCodeWorks.Mvvm
                     }
                     await RefreshAsync(token);
                 }
-
                 else if (RefreshCommand is IAsyncRelayCommand asyncCommand && asyncCommand.ExecutionTask is not null)
                 {
                     var task = asyncCommand.ExecutionTask;

--- a/src/Mvvm.Controls/Mvvm/RefreshableSelector.cs
+++ b/src/Mvvm.Controls/Mvvm/RefreshableSelector.cs
@@ -124,9 +124,11 @@ namespace RFBCodeWorks.Mvvm
             get => _isRefreshing == 1;
             private set
             {
-                (int x, int y) = value ? (1, 0) : (0, 1);
-                if (_isRefreshing.CompareExchange(x, y))
+                int newValue = value ? 1 : 0;
+                if (_isRefreshing != newValue)
                 {
+                    OnPropertyChanging(EventArgSingletons.IsRefreshing);
+                    _isRefreshing = newValue;
                     OnPropertyChanged(EventArgSingletons.IsRefreshing);
                 }
             }
@@ -186,9 +188,10 @@ namespace RFBCodeWorks.Mvvm
             }
 
             // this thread starts the refresh
+            OnPropertyChanging(EventArgSingletons.IsRefreshing);
             var task =  DoRefreshTask(token);
             _isRefreshingTcs = task;
-            OnPropertyChanged(nameof(IsRefreshing));
+            OnPropertyChanged(EventArgSingletons.IsRefreshing);
             return task;
         }
 
@@ -206,7 +209,7 @@ namespace RFBCodeWorks.Mvvm
             }
         }
 
-
+        private void ResetInitializedState() => Interlocked.Exchange(ref itemsInitialized, 0);
         private bool RequiresInitialization() => IsRefreshing == false && Interlocked.Exchange(ref itemsInitialized, 1) < 1;
         private static int SetRequiresInitialization(bool refreshOnFirstCollectionRequest) => refreshOnFirstCollectionRequest ? -1 : 0;
 
@@ -218,65 +221,100 @@ namespace RFBCodeWorks.Mvvm
 
         /// <summary>
         /// Checks if the <see cref="Items"/> collection has been initialized.
-        /// <br/>Calls <see cref="Refresh()"/> if required.
+        /// <br/> Will only trigger a refresh if the collection has not been initialized yet.
         /// </summary>
         /// <param name="maxWaitTime">
-        /// Maximum time delay to block the thread while waiting for an asynchronous refresh to complete.
+        /// <see langword="Note:"/>  
+        /// <br/> - This parameter will only take effect for asynchronous refreshes that respect cancellation, or if the refresh was already triggered from another thread.
+        /// <br/> - <see cref="EnsureInitializedAsync(CancellationToken)"/> should be preferred where possible, especially from a UI thread.
+        /// <para/> Maximum time delay to block the thread while waiting for an asynchronous refresh to complete.
         /// <br/> If not specified, defaults to 3 seconds.
         /// </param>
+        /// <exception cref="RefreshFailedException" />
+        /// <exception cref="OperationCanceledException" />
         public void EnsureInitialized(TimeSpan? maxWaitTime = null)
         {
+            bool usingToken = false;
             try
             {
                 if (RequiresInitialization())
-                    Refresh();
+                {
+                    if (RefreshCommand.CanExecute(null) == false)
+                    {
+                        ThrowRefreshFailedException("Unable to initialize collection: RefreshCommand.CanExecute() returned false");
+                    }
+                    if (RefreshCommand is IAsyncRelayCommand)
+                    {
+                        usingToken = true;
+                        using CancellationTokenSource waitTime = new(maxWaitTime ?? TimeSpan.FromMilliseconds(3000));
+                        RefreshAsync(waitTime.Token).Wait(waitTime.Token);
+                    }
+                    else
+                    {
+                        RefreshCommand.Execute(null);
+                    }
+                }
                 else if (IsRefreshing)
                 {
+                    usingToken = true;
                     using CancellationTokenSource waitTime = new(maxWaitTime ?? TimeSpan.FromMilliseconds(3000));
-                    while (IsRefreshing && !waitTime.IsCancellationRequested)
-                    {
-                        Thread.Sleep(0);
-                    }
-                    if (waitTime.IsCancellationRequested)
-                        ThrowRefreshFailedException("Exceeded maximum wait time for collection initialization.");
+                    SpinWait.SpinUntil(() => waitTime.IsCancellationRequested || IsRefreshing == false);
+                    
+                    if (IsRefreshing) 
+                        waitTime.Token.ThrowIfCancellationRequested();
                 }
             }
-            catch (RefreshFailedException) { throw; }
+            catch (RefreshFailedException) { ResetInitializedState(); throw; }
+            catch (OperationCanceledException e) when (usingToken)
+            {
+                ResetInitializedState();
+                ThrowRefreshFailedException("Exceeded maximum wait time for collection initialization.", e);
+            }
             catch (Exception e)
             {
+                ResetInitializedState();
                 ThrowRefreshFailedException(innerException: e);
             }
             if (Items is null)
+            {
+                ResetInitializedState();
                 ThrowRefreshFailedException("Collection initialization failed: Items collection is null.");
-            if (itemsInitialized != 1)
-                ThrowRefreshFailedException("Collection initialization failed: Collection was not updated");
+            }
         }
 
         /// <summary>
-        /// Checks if the collection has been initialized
+        /// Checks if the collection has been initialized. 
+        /// <br/> Will only trigger a refresh if the collection has not been initialized yet.
         /// </summary>
-        /// <exception cref="RefreshFailedException"/>
+        /// <exception cref="RefreshFailedException" />
+        /// <exception cref="OperationCanceledException" />
         public async Task EnsureInitializedAsync(CancellationToken token)
         {
             try
             {
                 if (RequiresInitialization())
                 {
+                    if (RefreshCommand.CanExecute(null) == false)
+                    {
+                        ThrowRefreshFailedException("Unable to initialize collection: RefreshCommand.CanExecute() returned false");
+                    }
                     await RefreshAsync(token);
                 }
 
                 else if (RefreshCommand is IAsyncRelayCommand asyncCommand && asyncCommand.ExecutionTask is not null)
                 {
                     var task = asyncCommand.ExecutionTask;
-
                     if (task.Status < TaskStatus.RanToCompletion)
                     {
                         var tcs = new TaskCompletionSource<object>();
                         using var reg = token.Register(() => tcs.SetCanceled());
-                        await Task.WhenAny(tcs.Task, task); // returns to caller when the next collection is completed or faulted
+                        var completedTask = await Task.WhenAny(tcs.Task, task); // returns when cancellation is requested or the refresh task completes
+                        if (completedTask == tcs.Task)
+                        {
+                            token.ThrowIfCancellationRequested();
+                        }
                     }
-                    else
-                        await task;
+                    await task;
                 }
 
                 else if (IsRefreshing)
@@ -288,17 +326,21 @@ namespace RFBCodeWorks.Mvvm
                     }
                 }
             }
-            catch (OperationCanceledException) { throw; }
-            catch (RefreshFailedException) { throw; }
+            catch (OperationCanceledException) { ResetInitializedState(); throw; }
+            catch (RefreshFailedException) { ResetInitializedState(); throw; }
             catch (Exception e)
             {
+                ResetInitializedState();
                 ThrowRefreshFailedException(innerException: e);
             }
             if (Items is null)
+            {
+                ResetInitializedState();
                 ThrowRefreshFailedException("Collection initialization failed: Items collection is null.");
-            if (itemsInitialized != 1)
-                ThrowRefreshFailedException("Collection initialization failed: Collection was not updated");
+            }
         }
+
+        
 
         /// <inheritdoc/>
         public void Refresh(object? sender, EventArgs e) => RefreshCommand.Execute(null);

--- a/src/Mvvm.Controls/Mvvm/RefreshableSelector.cs
+++ b/src/Mvvm.Controls/Mvvm/RefreshableSelector.cs
@@ -50,7 +50,7 @@ namespace RFBCodeWorks.Mvvm
         {
             _refresh = refresh;
             _canRefresh = canRefresh ?? ReturnTrue;
-            itemsInitialized = !refreshOnFirstCollectionRequest;
+            itemsInitialized = SetRequiresInitialization(refreshOnFirstCollectionRequest);
         }
 
         /// <inheritdoc cref="RefreshableSelector{T, TList, TSelectedValue}.RefreshableSelector(Func{TList}, Func{bool}, Action, Action, bool)"/>
@@ -67,7 +67,7 @@ namespace RFBCodeWorks.Mvvm
             _cancellableRefreshAsync = (c) => refreshAsync();
             _cancelRefreshCommand = InactiveButton.Instance;
             _canRefresh = canRefresh ?? ReturnTrue;
-            itemsInitialized = !refreshOnFirstCollectionRequest;
+            itemsInitialized = SetRequiresInitialization(refreshOnFirstCollectionRequest);
         }
 
         /// <inheritdoc cref="RefreshableSelector{T, TList, TSelectedValue}.RefreshableSelector(Func{TList}, Func{bool}, Action, Action, bool)"/>
@@ -81,7 +81,7 @@ namespace RFBCodeWorks.Mvvm
         {
             _cancellableRefreshAsync = refreshAsyncCancellable;
             _canRefresh = canRefresh ?? ReturnTrue;
-            itemsInitialized = !refreshOnFirstCollectionRequest;
+            itemsInitialized = SetRequiresInitialization(refreshOnFirstCollectionRequest);
         }
 
         /// <inheritdoc cref="RefreshableSelector{T, TList, TSelectedValue}.RefreshableSelector(Func{TList}, Func{bool}, Action, Action, bool)"/>
@@ -91,7 +91,7 @@ namespace RFBCodeWorks.Mvvm
 
         private IRelayCommand? _refreshCommand;
         private ICommand? _cancelRefreshCommand;
-        private bool itemsInitialized;
+        private int itemsInitialized;
         private int _isRefreshing;
         private readonly Func<bool> _canRefresh;
         private readonly Func<TList>? _refresh;
@@ -103,9 +103,8 @@ namespace RFBCodeWorks.Mvvm
         {
             get
             {
-                if (!itemsInitialized)
+                if (itemsInitialized.CompareExchange(1, -1))
                 {
-                    itemsInitialized = true;
                     RefreshCommand.Execute(null);
                 }
                 return base.Items;
@@ -113,7 +112,7 @@ namespace RFBCodeWorks.Mvvm
             set
             {
                 base.Items = value;
-                itemsInitialized = true;
+                itemsInitialized = 1;
             }
         }
 
@@ -125,10 +124,9 @@ namespace RFBCodeWorks.Mvvm
             get => _isRefreshing == 1;
             private set
             {
-                if (value != IsRefreshing)
+                (int x, int y) = value ? (1, 0) : (0, 1);
+                if (_isRefreshing.CompareExchange(x, y))
                 {
-                    OnPropertyChanging(EventArgSingletons.IsRefreshing);
-                    _isRefreshing = value ? 1 : 0;
                     OnPropertyChanged(EventArgSingletons.IsRefreshing);
                 }
             }
@@ -207,7 +205,100 @@ namespace RFBCodeWorks.Mvvm
                 OnPropertyChanged(nameof(IsRefreshing));
             }
         }
-        
+
+
+        private bool RequiresInitialization() => IsRefreshing == false && Interlocked.Exchange(ref itemsInitialized, 1) < 1;
+        private static int SetRequiresInitialization(bool refreshOnFirstCollectionRequest) => refreshOnFirstCollectionRequest ? -1 : 0;
+
+#if NET8_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.DoesNotReturn]
+#endif
+        private static void ThrowRefreshFailedException(string message = "Collection initialization failed", Exception? innerException = null)
+            => throw new RefreshFailedException(message, innerException);
+
+        /// <summary>
+        /// Checks if the <see cref="Items"/> collection has been initialized.
+        /// <br/>Calls <see cref="Refresh()"/> if required.
+        /// </summary>
+        /// <param name="maxWaitTime">
+        /// Maximum time delay to block the thread while waiting for an asynchronous refresh to complete.
+        /// <br/> If not specified, defaults to 3 seconds.
+        /// </param>
+        public void EnsureInitialized(TimeSpan? maxWaitTime = null)
+        {
+            try
+            {
+                if (RequiresInitialization())
+                    Refresh();
+                else if (IsRefreshing)
+                {
+                    using CancellationTokenSource waitTime = new(maxWaitTime ?? TimeSpan.FromMilliseconds(3000));
+                    while (IsRefreshing && !waitTime.IsCancellationRequested)
+                    {
+                        Thread.Sleep(0);
+                    }
+                    if (waitTime.IsCancellationRequested)
+                        ThrowRefreshFailedException("Exceeded maximum wait time for collection initialization.");
+                }
+            }
+            catch (RefreshFailedException) { throw; }
+            catch (Exception e)
+            {
+                ThrowRefreshFailedException(innerException: e);
+            }
+            if (Items is null)
+                ThrowRefreshFailedException("Collection initialization failed: Items collection is null.");
+            if (itemsInitialized != 1)
+                ThrowRefreshFailedException("Collection initialization failed: Collection was not updated");
+        }
+
+        /// <summary>
+        /// Checks if the collection has been initialized
+        /// </summary>
+        /// <exception cref="RefreshFailedException"/>
+        public async Task EnsureInitializedAsync(CancellationToken token)
+        {
+            try
+            {
+                if (RequiresInitialization())
+                {
+                    await RefreshAsync(token);
+                }
+
+                else if (RefreshCommand is IAsyncRelayCommand asyncCommand && asyncCommand.ExecutionTask is not null)
+                {
+                    var task = asyncCommand.ExecutionTask;
+
+                    if (task.Status < TaskStatus.RanToCompletion)
+                    {
+                        var tcs = new TaskCompletionSource<object>();
+                        using var reg = token.Register(() => tcs.SetCanceled());
+                        await Task.WhenAny(tcs.Task, task); // returns to caller when the next collection is completed or faulted
+                    }
+                    else
+                        await task;
+                }
+
+                else if (IsRefreshing)
+                {
+                    // handle synchronous refresh from another thread
+                    while (IsRefreshing)
+                    {
+                        await Task.Delay(50, token);
+                    }
+                }
+            }
+            catch (OperationCanceledException) { throw; }
+            catch (RefreshFailedException) { throw; }
+            catch (Exception e)
+            {
+                ThrowRefreshFailedException(innerException: e);
+            }
+            if (Items is null)
+                ThrowRefreshFailedException("Collection initialization failed: Items collection is null.");
+            if (itemsInitialized != 1)
+                ThrowRefreshFailedException("Collection initialization failed: Collection was not updated");
+        }
 
         /// <inheritdoc/>
         public void Refresh(object? sender, EventArgs e) => RefreshCommand.Execute(null);

--- a/src/Mvvm.Controls/SystemExtensions.cs
+++ b/src/Mvvm.Controls/SystemExtensions.cs
@@ -1,10 +1,21 @@
 ﻿using System;
 using System.Runtime.CompilerServices;
+using System.Threading;
 
 namespace RFBCodeWorks
 {
     internal static class SystemExtensions
     {
+        /// <summary>
+        /// Compares the <paramref name="value"/> to the <paramref name="expectedValue"/>. If the match, set the value to <paramref name="newValue"/> and returns true.
+        /// </summary>
+        /// <returns>Returns true if the original value = the <paramref name="expectedValue"/></returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool CompareExchange(this ref int value, int newValue, int expectedValue)
+        {
+            return Interlocked.CompareExchange(ref value, newValue, expectedValue) == expectedValue;
+        }
+
         /// <summary>
         /// Generic function to check if an object is null
         /// </summary>

--- a/src/Mvvm.Controls/SystemExtensions.cs
+++ b/src/Mvvm.Controls/SystemExtensions.cs
@@ -7,9 +7,9 @@ namespace RFBCodeWorks
     internal static class SystemExtensions
     {
         /// <summary>
-        /// Compares the <paramref name="value"/> to the <paramref name="expectedValue"/>. If the match, set the value to <paramref name="newValue"/> and returns true.
+        /// Compares the <paramref name="value"/> to the <paramref name="expectedValue"/>. If they match, sets the value to <paramref name="newValue"/> and returns true.
         /// </summary>
-        /// <returns>Returns true if the original value = the <paramref name="expectedValue"/></returns>
+        /// <returns>Returns true if the original value equals the <paramref name="expectedValue"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool CompareExchange(this ref int value, int newValue, int expectedValue)
         {

--- a/src/Mvvm.Version.targets
+++ b/src/Mvvm.Version.targets
@@ -3,7 +3,7 @@
 
     <!-- Set the Version Information for entire solution -->
     <PropertyGroup>
-        <Version>2.0.1.0</Version>
+        <Version>2.0.1.1</Version>
 		<PackageReleaseNotes>
 - Added generators for VS-2026
 - RFBCodeWorks.Mvvm.UIServices methods are now marked obsolete. Use ICursorService instead.

--- a/tests/MvvmControlsTests/Mvvm.Tests/RefreshableSelectorTests.cs
+++ b/tests/MvvmControlsTests/Mvvm.Tests/RefreshableSelectorTests.cs
@@ -21,19 +21,147 @@ namespace RFBCodeWorks.Mvvm.Tests
             await Task.Delay(250, token);
             return GetIntegers();
         }
+        private static int[] Throws() => throw new NotImplementedException();
+        private async Task<int[]> ThrowsAsync()
+        {
+            await Task.Delay(100, TestContext.CancellationToken);
+            return Throws();
+        }
+
+        private static void AssertInitialCount(ISelector selector, bool refreshOnFirstRequest, bool isAsync)
+        {
+            if (refreshOnFirstRequest && !isAsync)
+                Assert.HasCount(6, selector.Items, "\n >> Collection was not refreshed when accessing Selector.Items");
+            else
+                Assert.HasCount(0, selector.Items, "\n >> Collection had values unexpectedly on first access of Selector.Items");
+        }
 
         [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
-        public void Test_RefreshOnInitialize_Synchronous(bool enabled)
+        public void Test_EnsureInitialized_DoesNotRefreshIfAlreadyInitialized(bool refreshOnFirstRequest)
         {
-            var selector = new RefreshableSelector<int, int[], object>(GetIntegers, refreshOnFirstCollectionRequest: enabled);
-            
-            if (enabled)
-                Assert.HasCount(6, selector.Items);
-            else
-                Assert.HasCount(0, selector.Items);
+            int count = 0;
+            int[] Run() { count++; return GetIntegers(); }
+            var selector = new RefreshableSelector<int, int[], object>(Run, refreshOnFirstCollectionRequest: refreshOnFirstRequest);
+            AssertInitialCount(selector, refreshOnFirstRequest, false);
+            Assert.AreEqual(refreshOnFirstRequest ? 1 : 0, count);
 
+            // reset for ease of testing
+            count = 0;
+            selector.Refresh();
+            Assert.AreEqual(1, count, "\n >> count was not updated after refresh");
+            selector.EnsureInitialized();
+            Assert.AreEqual(1, count, "\n >> count was updated unexpected after EnsureInitialize");
+            Assert.HasCount(6, selector.Items, "\n >> Collection was not expected count after EnsureInitialized was called");
+        }
+
+        [TestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
+        public async Task Test_EnsureInitializedAsync_DoesNotRefreshIfAlreadyInitialized(bool refreshOnFirstRequest)
+        {
+            int count = 0;
+            Task<int[]> Run() { count++; return GetIntegersAsync(Token); }
+            var selector = new RefreshableSelector<int, int[], object>(Run, refreshOnFirstCollectionRequest: refreshOnFirstRequest);
+            AssertInitialCount(selector, refreshOnFirstRequest, true);
+            Assert.AreEqual(refreshOnFirstRequest ? 1 : 0, count);
+            await selector.EnsureInitializedAsync(Token); // waits for first refresh complete
+            Assert.AreEqual(1, count, "\n >> count was not updated on first refresh");
+
+            await selector.RefreshAsync(Token);
+            Assert.AreEqual(2, count, "\n >> count was not updated after refresh");
+            await selector.EnsureInitializedAsync(Token);
+            Assert.AreEqual(2, count, "\n >> count was updated unexpected after EnsureInitialize");
+            Assert.HasCount(6, selector.Items, "\n >> Collection was not expected count after EnsureInitialized was called");
+        }
+
+        [TestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
+        public void Test_EnsureInitialized(bool refreshOnFirstRequest)
+        {
+            var selector = new RefreshableSelector<int, int[], object>(GetIntegers, refreshOnFirstCollectionRequest: refreshOnFirstRequest);
+            AssertInitialCount(selector, refreshOnFirstRequest, false);
+            selector.EnsureInitialized();
+            Assert.HasCount(6, selector.Items, "\n >> Collection was not expected count after EnsureInitialized was called");
+        }
+
+        [TestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
+        public void Test_EnsureInitialized_AsynchronousRefresh(bool refreshOnFirstRequest)
+        {
+            var selector = new RefreshableSelector<int, int[], object>(GetIntegersAsync, refreshOnFirstCollectionRequest: refreshOnFirstRequest);
+            AssertInitialCount(selector, refreshOnFirstRequest, true);
+            selector.EnsureInitialized();
+            Assert.HasCount(6, selector.Items, "\n >> Collection was not expected count after EnsureInitialized was called");
+        }
+
+        [TestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
+        public async Task Test_EnsureInitializedAsync(bool refreshOnFirstRequest)
+        {
+            var selector = new RefreshableSelector<int, int[], object>(GetIntegersAsync, refreshOnFirstCollectionRequest: refreshOnFirstRequest);
+            AssertInitialCount(selector, refreshOnFirstRequest, true);
+            await selector.EnsureInitializedAsync(TestContext.CancellationToken);
+            Assert.HasCount(6, selector.Items, "\n >> Collection was not expected count after EnsureInitializedAsync was called");
+        }
+
+        [TestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
+        public async Task Test_EnsureInitializedAsync_SynchronousRefresh(bool refreshOnFirstRequest)
+        {
+            var selector = new RefreshableSelector<int, int[], object>(GetIntegers, refreshOnFirstCollectionRequest: refreshOnFirstRequest);
+            AssertInitialCount(selector, refreshOnFirstRequest, false);
+            await selector.EnsureInitializedAsync(TestContext.CancellationToken);
+            Assert.HasCount(6, selector.Items, "\n >> Collection was not expected count after EnsureInitializedAsync was called");
+        }
+
+        [TestMethod]
+        public void Test_EnsureInitialized_Throws_SynchronousRefresh()
+        {
+            var selector = new RefreshableSelector<int, int[], object>(Throws);
+            Assert.Throws<RefreshFailedException>(() => selector.EnsureInitialized());
+        }
+
+        [TestMethod]
+        public void Test_EnsureInitialized_Throws_AynchronousRefresh()
+        {
+            var selector = new RefreshableSelector<int, int[], object>(ThrowsAsync);
+            Assert.Throws<RefreshFailedException>(() => selector.EnsureInitialized());
+        }
+
+        [TestMethod]
+        public void Test_EnsureInitialized_Throws_ExceedsWaitTime()
+        {
+            var selector = new RefreshableSelector<int, int[], object>(ThrowsAsync);
+            Assert.Throws<RefreshFailedException>(() => selector.EnsureInitialized(TimeSpan.Zero));
+        }
+
+        [TestMethod]
+        public async Task Test_EnsureInitializedAsync_Throws_SynchronousRefresh()
+        {
+            var selector = new RefreshableSelector<int, int[], object>(Throws);
+            await Assert.ThrowsAsync<RefreshFailedException>(() => selector.EnsureInitializedAsync(TestContext.CancellationToken));
+        }
+
+        [TestMethod]
+        public async Task Test_EnsureInitializedAsync_Throws_AsynchronousRefresh()
+        {
+            var selector = new RefreshableSelector<int, int[], object>(ThrowsAsync);
+            await Assert.ThrowsAsync<RefreshFailedException>(() => selector.EnsureInitializedAsync(TestContext.CancellationToken));
+        }
+
+        [TestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
+        public void Test_RefreshOnInitialize_Synchronous(bool refreshOnFirstRequest)
+        {
+            var selector = new RefreshableSelector<int, int[], object>(GetIntegers, refreshOnFirstCollectionRequest: refreshOnFirstRequest);
+            AssertInitialCount(selector, refreshOnFirstRequest, false);
             Assert.IsFalse(selector.IsRefreshing);
         }
 
@@ -104,20 +232,28 @@ namespace RFBCodeWorks.Mvvm.Tests
 
             var t1 = command.ExecuteAsync(Token);
             Assert.HasCount(1, tasks);
+            
             var t2 = command.ExecuteAsync(Token);
             Assert.HasCount(2, tasks);
+
             await Assert.ThrowsAsync<OperationCanceledException>(() => t1);
-            Assert.IsTrue(t1.IsCompleted);
+            Assert.IsTrue(t1.IsCanceled);
+
             Assert.IsFalse(t2.IsCompleted);
+            factory.LastTCS!.SetResult([]);
+            Assert.IsTrue(t2.IsCompleted);
         }
         private class TaskFactory
         {
+            public TaskCompletionSource<int[]>? LastTCS { get; private set; }
+
             public event EventHandler<(TaskCompletionSource<int[]> tcs, CancellationTokenRegistration reg)>? Created;
             public Task<int[]> Create(CancellationToken token)
             {
                 var tcs = new TaskCompletionSource<int[]>();
                 var reg = token.Register(() => tcs.SetCanceled());
                 Created?.Invoke(this, (tcs, reg));
+                LastTCS = tcs;
                 return tcs.Task;
             }
         }

--- a/tests/MvvmControlsTests/Mvvm.Tests/RefreshableSelectorTests.cs
+++ b/tests/MvvmControlsTests/Mvvm.Tests/RefreshableSelectorTests.cs
@@ -52,7 +52,7 @@ namespace RFBCodeWorks.Mvvm.Tests
             selector.Refresh();
             Assert.AreEqual(1, count, "\n >> count was not updated after refresh");
             selector.EnsureInitialized();
-            Assert.AreEqual(1, count, "\n >> count was updated unexpected after EnsureInitialize");
+            Assert.AreEqual(1, count, "\n >> count was updated unexpected after EnsureInitialized");
             Assert.HasCount(6, selector.Items, "\n >> Collection was not expected count after EnsureInitialized was called");
         }
 
@@ -72,8 +72,8 @@ namespace RFBCodeWorks.Mvvm.Tests
             await selector.RefreshAsync(Token);
             Assert.AreEqual(2, count, "\n >> count was not updated after refresh");
             await selector.EnsureInitializedAsync(Token);
-            Assert.AreEqual(2, count, "\n >> count was updated unexpected after EnsureInitialize");
-            Assert.HasCount(6, selector.Items, "\n >> Collection was not expected count after EnsureInitialized was called");
+            Assert.AreEqual(2, count, "\n >> count was updated unexpected after EnsureInitializedAsync");
+            Assert.HasCount(6, selector.Items, "\n >> Collection was not expected count after EnsureInitializedAsync was called");
         }
 
         [TestMethod]
@@ -128,7 +128,7 @@ namespace RFBCodeWorks.Mvvm.Tests
         }
 
         [TestMethod]
-        public void Test_EnsureInitialized_Throws_AynchronousRefresh()
+        public void Test_EnsureInitialized_Throws_AsynchronousRefresh()
         {
             var selector = new RefreshableSelector<int, int[], object>(ThrowsAsync);
             Assert.Throws<RefreshFailedException>(() => selector.EnsureInitialized());


### PR DESCRIPTION
- Adds EnsureInitialized() and EnsureInitializedAsync to the RefreshableSelectors to allow callers to conditionally perform the first refresh and wait for its completion.
- Added RefreshFailedException to allow EnsureInitialized to provide more details about the failure
